### PR TITLE
Read env var to compile custom service definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ for _ in 0..10 {
 }
 ```
 
+### Using Custom Service Definitions
+
+If you have a set of custom service definitions, for example from [KRPC.MechJeb](https://github.com/Genhis/KRPC.MechJeb) you can put them all in a directory and point the `KRPC_SERVICES` environment variable to it at build time, this crate will generate a rust client implementation for them.
+
+Important: If you do this you have to provide *all* service definitions, even the ones this crate usually  includes
+
 ### Features
 * `fmt` (default): Format generated services. Remove for a quicker build producing an unreadable file.
 

--- a/build.rs
+++ b/build.rs
@@ -37,5 +37,13 @@ fn main() {
         .unwrap();
 
     let mut f = File::create(proto_path.join("services.rs")).unwrap();
-    krpc_build::build("service_definitions/", &mut f).unwrap();
+    if let Some(path) = env::var("KRPC_SERVICES")
+        .ok()
+        .map(|path| Path::new(&path).to_owned())
+        .filter(|path| path.exists())
+    {
+        krpc_build::build(path.to_str().unwrap(), &mut f).unwrap();
+    } else {
+        krpc_build::build("service_definitions/", &mut f).unwrap();
+    }
 }


### PR DESCRIPTION
This should resolve #13. 
The build script reads the `KRPC_SERVICES` env var and if it exists use that directory to look for service definitions to compile.
This still needs to be documented in the readme but I'm unsure where